### PR TITLE
add schema property to the model instance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,10 @@ declare namespace OttomanJS {
 
   }
 
+  interface ModelSchema {
+    validate<T> (mdlInst: T, callback: ValidateCallback<T>): void
+  }
+
   interface Indices {
   }
 
@@ -38,12 +42,15 @@ declare namespace OttomanJS {
   type CreateCallback<T> = (error: CouchbaseError | null, document: ModelInstance<T> | undefined) => void
   type GetByIdCallback<T> = (error: CouchbaseError | null, model: ModelInstance<T> | undefined) => void
   type SaveCallback<T> = (error: CouchbaseError | null, response: ModelInstance<T> | undefined) => void
+  type ValidateCallback<T> = (error: CouchbaseError | null) => void
 
   class ModelInstance<T> {
+    constructor(data: any)
     fromData<T> (data: any): T
     getById<T> (id: string, callback: GetByIdCallback<T>): void
     create<T> (data: any, callback: CreateCallback<T>): void
     save (callback: SaveCallback<T>): void
+    schema: ModelSchema
   }
 
   interface ModelInstanceCtor {

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,6 @@ declare namespace OttomanJS {
   type ValidateCallback<T> = (error: CouchbaseError | null) => void
 
   class ModelInstance<T> {
-    constructor(data: any)
     fromData<T> (data: any): T
     getById<T> (id: string, callback: GetByIdCallback<T>): void
     create<T> (data: any, callback: CreateCallback<T>): void


### PR DESCRIPTION
adding the `schema` property to the mode instance in order to access the `validate` method.

this is link https://ibb.co/nhN0oS of an image (screen shot from vs-code debug console) of the available methods and properties of the `model instance`
