### PR TITLE
Adds schema validation method into `Schema`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,9 +22,13 @@ declare namespace OttomanJS {
     namespace?: string
   }
 
+  interface ModelReference {
+    ref: string
+  }
+
   type ValidatorFunction = (value: any) => void
   interface SchemaField {
-    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date' | 'mixed',
+    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date' | 'mixed' | ModelReference,
     auto: 'uuid',
     readonly: boolean,
     validator: ValidatorFunction
@@ -38,7 +42,13 @@ declare namespace OttomanJS {
     validate<T> (modelInstance: ModelInstance<T>, callback: ValidationCallback<T>): void
   }
 
-  interface Indices {
+  interface Index {
+    type: 'refdoc' | 'view' | 'n1ql',
+    by: string
+  }
+
+  interface IndexDefinition {
+    [key: string]: Partial<Index>
   }
 
   interface GetByIdOptions {
@@ -74,7 +84,7 @@ declare namespace OttomanJS {
 
     constructor (options: OttomanOptions)
 
-    model (key: string, schema: SchemaDefinition, index: Indices): ModelInstanceCtor
+    model (key: string, schema: SchemaDefinition, index: IndexDefinition): ModelInstanceCtor
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,10 @@ declare namespace OttomanJS {
 
   }
 
+  interface ModelSchema {
+    validate<T> (mdlInst: T, callback: ValidateCallback<T>): void
+  }
+
   interface Indices {
   }
 
@@ -38,12 +42,15 @@ declare namespace OttomanJS {
   type CreateCallback<T> = (error: CouchbaseError | null, document: ModelInstance<T> | undefined) => void
   type GetByIdCallback<T> = (error: CouchbaseError | null, model: ModelInstance<T> | undefined) => void
   type SaveCallback<T> = (error: CouchbaseError | null, response: ModelInstance<T> | undefined) => void
+  type ValidateCallback<T> = (error: CouchbaseError | null) => void
 
   class ModelInstance<T> {
+    constructor(data: any)
     fromData<T> (data: any): T
     getById<T> (id: string, callback: GetByIdCallback<T>): void
     create<T> (data: any, callback: CreateCallback<T>): void
     save (callback: SaveCallback<T>): void
+    schema: ModelSchema
   }
 
   interface ModelInstanceCtor {

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,10 +45,10 @@ declare namespace OttomanJS {
     getById<T> (id: string, callback: GetByIdCallback<T>): void
     create<T> (data: any, callback: CreateCallback<T>): void
     save (callback: SaveCallback<T>): void
-    schema: Schema
   }
 
   interface ModelInstanceCtor {
+    schema: Schema
   }
 
   class Ottoman {

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,11 +23,7 @@ declare namespace OttomanJS {
   }
 
   interface Schema {
-
-  }
-
-  interface ModelSchema {
-    validate<T> (mdlInst: T, callback: ValidateCallback<T>): void
+    validate<T> (modelInstance: ModelInstance<T>, callback: ValidationCallback<T>): void
   }
 
   interface Indices {
@@ -42,14 +38,14 @@ declare namespace OttomanJS {
   type CreateCallback<T> = (error: CouchbaseError | null, document: ModelInstance<T> | undefined) => void
   type GetByIdCallback<T> = (error: CouchbaseError | null, model: ModelInstance<T> | undefined) => void
   type SaveCallback<T> = (error: CouchbaseError | null, response: ModelInstance<T> | undefined) => void
-  type ValidateCallback<T> = (error: CouchbaseError | null) => void
+  type ValidationCallback<T> = (error: CouchbaseError | null) => void
 
   class ModelInstance<T> {
     fromData<T> (data: any): T
     getById<T> (id: string, callback: GetByIdCallback<T>): void
     create<T> (data: any, callback: CreateCallback<T>): void
     save (callback: SaveCallback<T>): void
-    schema: ModelSchema
+    schema: Schema
   }
 
   interface ModelInstanceCtor {

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,6 @@ declare namespace OttomanJS {
   type ValidateCallback<T> = (error: CouchbaseError | null) => void
 
   class ModelInstance<T> {
-    constructor(data: any)
     fromData<T> (data: any): T
     getById<T> (id: string, callback: GetByIdCallback<T>): void
     create<T> (data: any, callback: CreateCallback<T>): void

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace OttomanJS {
 
   type ValidatorFunction = (value: any) => void
   interface SchemaField {
-    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date', 'mixed',
+    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date' | 'mixed',
     auto: 'uuid',
     readonly: boolean,
     validator: ValidatorFunction

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,18 @@ declare namespace OttomanJS {
     namespace?: string
   }
 
+  type ValidatorFunction = (value: any) => void
+  interface SchemaField {
+    type: 'string' | 'number' | 'integer' | 'boolean' | 'Date', 'mixed',
+    auto: 'uuid',
+    readonly: boolean,
+    validator: ValidatorFunction
+  }
+
+  interface SchemaDefinition {
+    [key: string]: Partial<SchemaField>
+  }
+
   interface Schema {
     validate<T> (modelInstance: ModelInstance<T>, callback: ValidationCallback<T>): void
   }
@@ -62,7 +74,7 @@ declare namespace OttomanJS {
 
     constructor (options: OttomanOptions)
 
-    model (key: string, schema: Schema, index: Indices): ModelInstanceCtor
+    model (key: string, schema: SchemaDefinition, index: Indices): ModelInstanceCtor
   }
 }
 


### PR DESCRIPTION
Some slight modifications to PR https://github.com/mpapp/node-ottoman/pull/3 from @Mangetsu-exe

- Corrects the Schema type handling (there's a "Schema Definition" type that is the input to "model" method, and there's the "Schema" which is the object that has a "validate" method on it, that is available as the "schema" property on the model constructor type).
- Adds type information to IndexDefinition (which is the now renamed Indices): IndexDefinition consists of partial Index objects.