### PR TITLE
Make 'deferBuild' parameter to ensureIndices optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ var Furniture = ottoman.model('Furniture', {
 });
 ```
 
-Now we need to ensure that this index is available on the server for searching:
+Now we need to ensure that this index is available on the server for searching (1st param to `ensureIndices` enables or disables [deferred index building](https://blog.couchbase.com/deferring-of-index-creation/)):
 ```javascript
-ottoman.ensureIndices(function(err) {
+ottoman.ensureIndices(true, function(err) {
   if (err) return console.error(err);
 });
 ```
@@ -280,10 +280,12 @@ ottoman.model('User', {
 
 In order for indices to be created on the server, you must call the `ensureIndices` method.  This method will internally generate a list of indexes which will be used and the most optimal configuration for them and build any which are missing on the server.  This must be called after all models are defined, and it is a good idea to only call this when needed rather than any time your server is started.
 
+The 1st parameter passed to `ensureIndices` enables or disables [deferred index building](https://blog.couchbase.com/deferring-of-index-creation/).
+
 ```javascript
 var ottoman = require('ottoman');
 var models = require('./all_my_models');
-ottoman.ensureIndices(function(err) {
+ottoman.ensureIndices(true, function(err) {
   if (err) {
     console.log('failed to created necessary indices', err);
     return;

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,7 +101,7 @@ declare namespace OttomanJS {
     constructor (options: OttomanOptions)
 
     model (key: string, schema: SchemaDefinition, options: ModelOptions): ModelInstanceCtor
-    ensureIndices (callback: Function): void
+    ensureIndices (DeferBuild: boolean, callback: Function): void
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,7 @@ declare namespace OttomanJS {
   type GetByIdCallback<T> = (error: CouchbaseError | null, model: ModelInstance<T> | undefined) => void
   type SaveCallback<T> = (error: CouchbaseError | null, response: ModelInstance<T> | undefined) => void
   type ValidationCallback<T> = (error: CouchbaseError | null) => void
+  type EnsureIndicesCallback = (error: CouchbaseError | null) => void
 
   class ModelInstance<T> {
     fromData<T> (data: any): T
@@ -100,6 +101,7 @@ declare namespace OttomanJS {
     constructor (options: OttomanOptions)
 
     model (key: string, schema: SchemaDefinition, options: ModelOptions): ModelInstanceCtor
+    ensureIndices (callback: Function): void
   }
 }
 

--- a/lib/cbstoreadapter.js
+++ b/lib/cbstoreadapter.js
@@ -340,7 +340,7 @@ function _ottopathToN1qlPath(path) {
  * @private
  * @ignore
  */
-CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
+CbStoreAdapter.prototype._ensureGsiIndices = function (deferBuild, callback) {
   var queries = [];
   var indexes = [];
 
@@ -405,7 +405,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
         fieldNames.join(',') +
         ') ' +
         'WHERE _type="' + gsi.modelName + '" ' +
-        'USING GSI WITH {\"defer_build\": true}');
+        'USING GSI WITH {\"defer_build\": ' + deferBuild + '}');
 
       // Keep track of all indexes we are creating, so we can
       // build them later.
@@ -446,7 +446,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
       indexes.push('Ottoman__type');
       // Create ottoman type index, needed to make model lookups fast.
       return queryPromise('CREATE INDEX `Ottoman__type` ON `' +
-        self.bucket._name + '`(`_type`) USING GSI WITH {"defer_build": true}');
+        self.bucket._name + '`(`_type`) USING GSI WITH {"defer_build": ' + deferBuild + '}');
     })
     .then(function () {
       // Map createIndex across all individual n1ql model indexes.
@@ -481,7 +481,7 @@ CbStoreAdapter.prototype._ensureGsiIndices = function (callback) {
  *
  * @param {StoreAdapter~EnsureCallback} callback
  */
-CbStoreAdapter.prototype.ensureIndices = function (callback) {
+CbStoreAdapter.prototype.ensureIndices = function (deferBuild, callback) {
   if (this.debug) {
     console.log('CbStoreAdapter::ensureIndices');
   }
@@ -494,7 +494,7 @@ CbStoreAdapter.prototype.ensureIndices = function (callback) {
       return;
     }
 
-    self._ensureGsiIndices(function (err) {
+    self._ensureGsiIndices(deferBuild, function (err) {
       if (err) {
         callback(err);
         return;

--- a/lib/ottoman.js
+++ b/lib/ottoman.js
@@ -918,7 +918,7 @@ Ottoman.prototype._ensureModelIndices = function (model, callback) {
  *
  * @param {Function} callback
  */
-Ottoman.prototype.ensureIndices = function (callback) {
+Ottoman.prototype.ensureIndices = function (deferBuild, callback) {
   var self = this;
 
   var models = [];
@@ -954,7 +954,7 @@ Ottoman.prototype.ensureIndices = function (callback) {
       }
     }
     for (var i = 0; i < stores.length; ++i) {
-      stores[i].ensureIndices(handler);
+      stores[i].ensureIndices(deferBuild, handler);
     }
   }
 

--- a/test/indexes.test.js
+++ b/test/indexes.test.js
@@ -30,7 +30,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var x = new TestMdl();
@@ -124,7 +124,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var x = new TestMdl();
@@ -162,7 +162,7 @@ describe('Model Indexes', function () {
           }
         });
 
-      ottoman.ensureIndices(function (err) {
+      ottoman.ensureIndices(true, function (err) {
         assert.isNull(err);
 
         var x = new TestMdl();
@@ -202,7 +202,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var x = new TestMdl();
@@ -241,7 +241,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var x = new TestMdl();
@@ -288,7 +288,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var x = new TestMdl();
@@ -325,7 +325,7 @@ describe('Model Indexes', function () {
         }
       });
 
-    ottoX.ensureIndices(function (err) {
+    ottoX.ensureIndices(true, function (err) {
       assert.isNotNull(err);
       done();
     });

--- a/test/instances.test.js
+++ b/test/instances.test.js
@@ -13,7 +13,7 @@ describe('Model Instances', function () {
   var testInstance = new TestMdl({ name: 'Joe Blow' });
 
   before (function (done) {
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       if (err) { return done(err); }
 
       // Guarantee at least one saved.

--- a/test/model-references.test.js
+++ b/test/model-references.test.js
@@ -45,7 +45,7 @@ describe('Model references', function () {
     });
 
   before(function (done) {
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       if (err) { return done(err); }
       setTimeout(function () { done(); }, 2000);
     });

--- a/test/queries.test.js
+++ b/test/queries.test.js
@@ -28,7 +28,7 @@ describe('Model Queries', function () {
       msg: 'string'
     });
 
-    ottoman.ensureIndices(function (err) {
+    ottoman.ensureIndices(true, function (err) {
       assert.isNull(err);
 
       var ux = new UserMdl();
@@ -104,7 +104,7 @@ describe('Model Queries', function () {
           }
         });
 
-      ottoman.ensureIndices(function (err) {
+      ottoman.ensureIndices(true, function (err) {
         assert.isNull(err);
 
         // Let index creation catch up.


### PR DESCRIPTION
Make 'deferBuild' parameter to ensureIndices optional such that indices can optionally built immediately (helpful for tests and apps that want to ensure primary indices are available before starting to respond to HTTP requests).